### PR TITLE
wire mesh render change

### DIFF
--- a/src/main/java/bvb/gui/shapes/GeneralPropertiesPanel.java
+++ b/src/main/java/bvb/gui/shapes/GeneralPropertiesPanel.java
@@ -19,6 +19,7 @@ public class GeneralPropertiesPanel extends JPanel
 	final BigVolumeBrowser bvb;
 	final JComboBox<String> cbBlending;
 	final NumberField nfSilhouetteDecay;
+	final NumberField nfWireLineWidth;
 	final NumberField nfCartesianStep;
 	final NumberField nfCartesianFraction;
 	
@@ -28,34 +29,47 @@ public class GeneralPropertiesPanel extends JPanel
 		
 		bvb = bvb_;
 		
+		int nDigitsFloatTextField = 4;
+		
 		setLayout(new GridBagLayout());
 		
 		GridBagConstraints gbc = new GridBagConstraints();
+
 		
-		//GBCHelper.alighLeft(gbc);
-		
-		String[] sBlending = {"Weighted OIT", "Alpha OVER"};
+		String[] sBlending = {"Weight OIT", "Alpha OVER"};
 		cbBlending = new JComboBox< >(sBlending);
 		cbBlending.addActionListener( (e)->{
 			updateBlending();				
 			});
 
-		nfSilhouetteDecay = new NumberField(5);		
-		nfSilhouetteDecay.setText( "1.0" );
+		nfSilhouetteDecay = new NumberField(nDigitsFloatTextField);		
+		nfSilhouetteDecay.setText( "1.00" );
+		nfSilhouetteDecay.setLimits( 0.0, Double.MAX_VALUE );
 		nfSilhouetteDecay.addListener( (v)->
 		{
 			updateSilhouetteDecay(Math.abs( v ));
 		} );
 		
-		nfCartesianStep = new NumberField(5);		
+		nfWireLineWidth = new NumberField(3);
+		nfWireLineWidth.setIntegersOnly( true );
+		nfWireLineWidth.setText( "1.0" );
+		nfWireLineWidth.setLimits( 0.0, Double.MAX_VALUE );
+		nfWireLineWidth.addListener( (v)->
+		{
+			updateWireLineWidth();
+		} );
+		
+		nfCartesianStep = new NumberField(nDigitsFloatTextField);		
 		nfCartesianStep.setText( "2.0" );
+		nfCartesianStep.setLimits( 0.0, Double.MAX_VALUE );
 		nfCartesianStep.addListener( (v)->
 		{
 			updateCartesianGrid();
 		} );
 		
-		nfCartesianFraction = new NumberField(5);		
+		nfCartesianFraction = new NumberField(nDigitsFloatTextField);		
 		nfCartesianFraction.setText( "0.2" );
+		nfCartesianFraction.setLimits( 0.0, Double.MAX_VALUE );
 		nfCartesianFraction.addListener( (v)->
 		{
 			updateCartesianGrid();
@@ -72,6 +86,12 @@ public class GeneralPropertiesPanel extends JPanel
 		this.add( new JLabel("Mesh silhouette decay: "), gbc );
 		gbc.gridx++;
 		this.add( nfSilhouetteDecay, gbc);
+		
+		gbc.gridx = 0;
+		gbc.gridy++;
+		this.add( new JLabel("Mesh wire line width: "), gbc );
+		gbc.gridx++;
+		this.add( nfWireLineWidth, gbc);
 		
 		gbc.gridx = 0;
 		gbc.gridy++;
@@ -119,6 +139,22 @@ public class GeneralPropertiesPanel extends JPanel
 			if(sh instanceof BasicMeshColor)
 			{
 				((BasicMeshColor)sh).setSilhouetteDecay( fv );
+			}
+		}
+		bvb.repaintBVV();
+
+	}
+	
+	synchronized void updateWireLineWidth()
+	{
+		final List< BasicShape> shapeList = bvb.shapes;
+		final float valWidth = Math.abs(Float.parseFloat( nfWireLineWidth.getText()));
+		
+		for ( final BasicShape sh: shapeList)
+		{
+			if(sh instanceof BasicMeshColor)
+			{
+				((BasicMeshColor)sh).setWireLineWidth( valWidth );
 			}
 		}
 		bvb.repaintBVV();

--- a/src/main/java/bvb/gui/shapes/MeshesPropertiesPanel.java
+++ b/src/main/java/bvb/gui/shapes/MeshesPropertiesPanel.java
@@ -161,11 +161,13 @@ public class MeshesPropertiesPanel extends JPanel
 		boolean bRenderSame = true;
 		boolean bColorSame = true;
 		boolean bPointSizeSame = true;
+		boolean bGridSame = true;
 		boolean bSurfaceSame = true;
 		float fPointSize = 0.0f;
 		Color currColor = Color.WHITE;
 		int nRender = 0;
 		int nSurface = 0;
+		int nGrid = 0;
 		final List< BasicShape> shapeList = bvb.selectedObjects.getSelectedShapes();
 		for ( final BasicShape sh: shapeList)
 		{
@@ -178,12 +180,14 @@ public class MeshesPropertiesPanel extends JPanel
 					currColor = meshShape.getColor();
 					fPointSize = meshShape.getPointSize();
 					nSurface = meshShape.getSurfaceRender();
+					nGrid = meshShape.getSurfaceGrid();
 					bFirstMesh = false;
 				}
 				else
 				{
 					bRenderSame &= (nRender ==  meshShape.getRenderType());
 					bSurfaceSame &= (nSurface == meshShape.getSurfaceRender());
+					bGridSame &= (nGrid == meshShape.getSurfaceGrid());
 					bColorSame &= currColor.equals( meshShape.getColor() );
 					bPointSizeSame &= Math.abs( fPointSize - meshShape.getPointSize())<0.0001;
 				}
@@ -194,10 +198,12 @@ public class MeshesPropertiesPanel extends JPanel
 		final float fPointSizeFin = fPointSize;
 		final int nRenderFin = nRender;
 		final int nSurfaceFin = nSurface;
+		final int nGridFin = nGrid;
 		final boolean bRenderSameFin = bRenderSame;
 		final boolean bColorSameFin = bColorSame;
 		final boolean bPointSizeSameFin = bPointSizeSame;
 		final boolean bSurfaceSameFin = bSurfaceSame;
+		final boolean bGridSameFin = bGridSame;
 
 		SwingUtilities.invokeLater( () -> {
 			synchronized ( MeshesPropertiesPanel.this )
@@ -210,19 +216,19 @@ public class MeshesPropertiesPanel extends JPanel
 					pColor.setConsistent( bColorSameFin );
 					pPointSize.setConsistent( bPointSizeSameFin );
 					pSurface.setConsistent( bSurfaceSameFin );
+					pGrid.setConsistent( bGridSameFin );
 					
 					if(bRenderSameFin)
 					{
 						cbRender.setSelectedIndex( nRenderFin );
 					}
+					
 					if(bColorSameFin)
 					{
 						selectColors.setColor( cColorFin, 0 );
 						butColor.setIcon(  new ColorIcon( cColorFin ) );
 					}
-					//if(bRenderSameFin && nRenderFin == VisMeshColor.POINTS)
-					//{
-						//nfMeshPointSize.setEnabled( true );
+
 					if(bPointSizeSameFin)
 					{
 						nfMeshPointSize.setText( String.format("%.2f", fPointSizeFin));
@@ -231,12 +237,11 @@ public class MeshesPropertiesPanel extends JPanel
 					{
 						cbSurface.setSelectedIndex( nSurfaceFin );
 					}
-						
-					//}
-					//else
-					//{
-					//	nfMeshPointSize.setEnabled( false );
-					//}
+					
+					if(bGridSameFin)
+					{
+						cbGrid.setSelectedIndex( nGridFin );
+					}
 				}
 				blockUpdates = false;
 			}

--- a/src/main/java/bvb/gui/shapes/PanelAddShapes.java
+++ b/src/main/java/bvb/gui/shapes/PanelAddShapes.java
@@ -301,8 +301,6 @@ public class PanelAddShapes extends JPanel
 		final WRLParser loaderWRT = new WRLParser();
 		//loaderWRT.nMaxMeshes = 4;
 		//loaderWRT.nMaxTimePoints = 1;
-		loaderWRT.bEnableWireGrid = true;
-		//loaderWRT.bEnableWireGrid = false;
 		final ArrayList< Mesh > loadedMeshes = loaderWRT.readWRL(sFilename);
 		
 		if(bGroupMesh)

--- a/src/main/java/bvb/io/shapes/WRLParser.java
+++ b/src/main/java/bvb/io/shapes/WRLParser.java
@@ -32,9 +32,7 @@ public class WRLParser
 	int nVertPerPrim;
 	long nLineN = 0;
 	int nTimePoint = -1;
-
 	
-	public boolean bEnableWireGrid = true;	
 	public int nMaxMeshes = Integer.MAX_VALUE;
 	public int nMaxTimePoints = Integer.MAX_VALUE;	
 	boolean bMeshOK = true;
@@ -428,22 +426,23 @@ public class WRLParser
 
 			}
 			else
-			{				
+			{		
+				//obsolete
 				//separate vertices per triangle,
 				//allows wireframe mesh render 
 				//but loads more data (adds extra vertices)
-				if(bEnableWireGrid)
-				{
-					addVertex(currMesh,vertices.get( currInd[k] ));
-					currInd[k] = newVindex;
-					newVindex++;
-				}
+//				if(bEnableWireGrid)
+//				{
+//					addVertex(currMesh,vertices.get( currInd[k] ));
+//					currInd[k] = newVindex;
+//					newVindex++;
+//				}
 				//shared vertices per triangle,
 				//does not always allow wireframe mesh render
-				else
-				{
-					currInd[k] = addedInd.get(currInd[k]).intValue();
-				}
+				//else
+				//{
+				currInd[k] = addedInd.get(currInd[k]).intValue();
+				//}
 			}
 		}
 		currMesh.triangles().addf( currInd[0], currInd[1], currInd[2]);

--- a/src/main/java/bvb/scene/VisMeshColor.java
+++ b/src/main/java/bvb/scene/VisMeshColor.java
@@ -31,6 +31,8 @@ package bvb.scene;
 import static com.jogamp.opengl.GL.GL_FLOAT;
 import static com.jogamp.opengl.GL.GL_TRIANGLES;
 import static com.jogamp.opengl.GL.GL_UNSIGNED_INT;
+import static com.jogamp.opengl.GL2GL3.GL_LINE;
+import static com.jogamp.opengl.GL2GL3.GL_FILL;
 
 import java.awt.Color;
 import java.nio.FloatBuffer;
@@ -47,8 +49,6 @@ import org.joml.Vector4f;
 import bvb.core.BVVSettings;
 
 import com.jogamp.opengl.GL;
-import com.jogamp.opengl.GL2ES1;
-import com.jogamp.opengl.GL2GL3;
 import com.jogamp.opengl.GL3;
 
 
@@ -83,9 +83,9 @@ public class VisMeshColor extends AbstractClipTransformVis
 
 	public static final int MESH = 0, POINTS = 1;	
 	
-	public int renderType = MESH;
+	int renderType = MESH;
 	
-	public float fPointSize = 0.1f;
+	float fPointSize = 0.1f;
 	
 	public static final int SURFACE_PLAIN = 0, SURFACE_SHADE = 1, SURFACE_SHINY = 2, SURFACE_SILHOUETTE = 3; 
 	
@@ -104,6 +104,8 @@ public class VisMeshColor extends AbstractClipTransformVis
 	float cartesianGridStep = 2.0f;
 	
 	float cartesianFraction = 0.2f;
+	
+	float fWireLineWidth = 1.0f;
 	
 	volatile boolean bLocked = false;
 	
@@ -165,6 +167,16 @@ public class VisMeshColor extends AbstractClipTransformVis
 		gridType = gridType_;		
 	}
 	
+	public int getSurfaceGridType()
+	{
+		return gridType;		
+	}
+	
+	public void setWireLineWidth(final float fIn)
+	{
+		fWireLineWidth = fIn;
+	}
+	
 	public void setCartesianGrid(final float cartesianGridStep_, final float cartesianFraction_)
 	{
 		cartesianGridStep = cartesianGridStep_;		
@@ -174,6 +186,11 @@ public class VisMeshColor extends AbstractClipTransformVis
 	public void setPointsSize(final float fPointSize_)
 	{
 		fPointSize = fPointSize_;
+	}
+	
+	public float getPointsSize()
+	{
+		return fPointSize;
 	}
 	
 	public void setSilhouetteDecay(final float silhouetteDecay_)
@@ -221,38 +238,15 @@ public class VisMeshColor extends AbstractClipTransformVis
 	/** upload MeshData to GPU **/
 	private boolean initGPUBufferMesh( GL3 gl )
 	{
-	
-		//build baricentric coordinates for each triangle
-		final float [] barycenter = new float [mesh.vertices().size()*3];
 		
 		final IntBuffer indicesT = mesh.triangles().indices().duplicate();
 		indicesT.rewind();
 
-		final int [] trindices = IntBuffertoArray(indicesT);
-
-		for(int i=0; i<trindices.length; i+=3)
-		{			
-			for(int j=0;j<3;j++)
-			{
-				for(int d=0;d<3;d++)
-				{
-					barycenter[trindices[i+j]*3+d] = 0.0f;
-				}
-				
-			}
-			for(int j=0;j<3;j++)
-			{
-				barycenter[trindices[i+j]*3+j] = 1.0f;
-			}
-
-		}
-
-		final int[] tmp = new int[ 4 ];
-		gl.glGenBuffers( 4, tmp, 0 );
+		final int[] tmp = new int[ 3 ];
+		gl.glGenBuffers( 3, tmp, 0 );
 		final int meshPosVbo = tmp[ 0 ];
 		final int meshNormalVbo = tmp[ 1 ];
-		final int meshBaryVbo = tmp[ 2 ];
-		final int meshEbo = tmp[ 3 ];
+		final int meshEbo = tmp[ 2 ];
 		
 		if(mesh == null)
 			return false;
@@ -271,10 +265,6 @@ public class VisMeshColor extends AbstractClipTransformVis
 		gl.glBindBuffer( GL.GL_ARRAY_BUFFER, meshNormalVbo );
 		gl.glBufferData( GL.GL_ARRAY_BUFFER, normals.limit() * Float.BYTES, normals, GL.GL_STATIC_DRAW );
 		gl.glBindBuffer( GL.GL_ARRAY_BUFFER, 0 );
-		
-		gl.glBindBuffer( GL.GL_ARRAY_BUFFER, meshBaryVbo );
-		gl.glBufferData( GL.GL_ARRAY_BUFFER, barycenter.length * Float.BYTES, FloatBuffer.wrap( barycenter ), GL.GL_STATIC_DRAW );
-		gl.glBindBuffer( GL.GL_ARRAY_BUFFER, 0 );
 
 		final IntBuffer indices = mesh.triangles().indices();
 		indices.rewind();
@@ -288,13 +278,11 @@ public class VisMeshColor extends AbstractClipTransformVis
 		gl.glBindBuffer( GL.GL_ARRAY_BUFFER, meshPosVbo );
 		gl.glVertexAttribPointer( 0, 3, GL_FLOAT, false, 3 * Float.BYTES, 0 );
 		gl.glEnableVertexAttribArray( 0 );
+
 		gl.glBindBuffer( GL.GL_ARRAY_BUFFER, meshNormalVbo );
 		gl.glVertexAttribPointer( 1, 3, GL_FLOAT, false, 3 * Float.BYTES, 0 );
 		gl.glEnableVertexAttribArray( 1 );
 
-		gl.glBindBuffer( GL.GL_ARRAY_BUFFER, meshBaryVbo );
-		gl.glVertexAttribPointer( 2, 3, GL_FLOAT, false, 3 * Float.BYTES, 0 );
-		gl.glEnableVertexAttribArray( 2 );
 		
 		gl.glBindBuffer( GL.GL_ELEMENT_ARRAY_BUFFER, meshEbo );
 		gl.glBindVertexArray( 0 );
@@ -380,11 +368,17 @@ public class VisMeshColor extends AbstractClipTransformVis
 
 //			gl.glEnable(GL.GL_BLEND);
 //			gl.glBlendFunc(GL.GL_SRC_ALPHA, GL.GL_ONE_MINUS_SRC_ALPHA);
-			//gl.glLineWidth( 1.0f );
-			//gl.glPolygonMode(GL.GL_FRONT_AND_BACK, GL2GL3.GL_LINE);
+			if(gridType == GRID_WIRE)
+			{
+				gl.glLineWidth( fWireLineWidth );
+				gl.glPolygonMode(GL.GL_FRONT_AND_BACK, GL_LINE);
+			}
 			gl.glBindVertexArray( vao );			
 			gl.glDrawElements( GL_TRIANGLES, mesh.triangles().size() * 3, GL_UNSIGNED_INT, 0 );
-			//gl.glPolygonMode(GL.GL_FRONT_AND_BACK, GL2GL3.GL_FILL);
+			if(gridType == GRID_WIRE)
+			{
+				gl.glPolygonMode(GL.GL_FRONT_AND_BACK, GL_FILL);
+			}
 			gl.glBindVertexArray( 0 );
 
 		}

--- a/src/main/java/bvb/shapes/BasicMeshColor.java
+++ b/src/main/java/bvb/shapes/BasicMeshColor.java
@@ -15,16 +15,22 @@ public interface BasicMeshColor
 	
 	public void setPointSize (final float fPointSize);
 	
-	public float getPointSize ();
-	
+	public float getPointSize();
+		
+	public void setSurfaceRender(final int nSurfaceRenderType);
+
 	public int getSurfaceRender();
 	
-	public void setSurfaceRender(final int nSurfaceRenderType);
-	
 	public void setSurfaceGrid(final int nSurfaceGridType);
+	
+	public int getSurfaceGrid();
 
+	public void setWireLineWidth(final float fThickness);
+	
 	public void setCartesianGrid(final float cartesianGridStep, final float cartesianFraction);
 	
 	public void setSilhouetteDecay(final float silhouetteDecay);
+	
+	
 	
 }

--- a/src/main/java/bvb/shapes/MeshColor.java
+++ b/src/main/java/bvb/shapes/MeshColor.java
@@ -185,6 +185,12 @@ public class MeshColor extends AbstractClipTransformSingleShape implements Basic
 	}
 	
 	@Override
+	public int getSurfaceGrid()
+	{
+		return ((VisMeshColor)visRender).getSurfaceGridType();
+	}
+	
+	@Override
 	public void setCartesianGrid(final float cartesianGridStep_, final float cartesianFraction_)
 	{
 		if(visRender != null )
@@ -221,7 +227,17 @@ public class MeshColor extends AbstractClipTransformSingleShape implements Basic
 	@Override
 	public float getPointSize()
 	{
-		return ((VisMeshColor)visRender).fPointSize;
+		return ((VisMeshColor)visRender).getPointsSize();
+	}
+	
+	
+	@Override
+	public void setWireLineWidth(final float fThickness)
+	{		
+		if(visRender != null )
+		{
+			((VisMeshColor)visRender).setWireLineWidth( fThickness );
+		}
 	}
 	
 	@Override

--- a/src/main/java/bvb/shapes/MultiMeshColor.java
+++ b/src/main/java/bvb/shapes/MultiMeshColor.java
@@ -129,6 +129,12 @@ public class MultiMeshColor extends AbstractClipTransformMulti implements BasicM
 	}
 	
 	@Override
+	public int getSurfaceGrid()
+	{
+		return ((VisMeshColor)visRendersTimeMap.keySet().toArray()[0]).getSurfaceGridType();
+	}
+	
+	@Override
 	public void setCartesianGrid(final float cartesianGridStep_, final float cartesianFraction_)
 	{
 		if(visRendersTimeMap.size()>0 )
@@ -176,6 +182,26 @@ public class MultiMeshColor extends AbstractClipTransformMulti implements BasicM
 	}
 	
 	@Override
+	public float getPointSize()
+	{
+		return ((VisMeshColor)visRendersTimeMap.keySet().toArray()[0]).getPointsSize();
+	}
+	
+	@Override
+	public void setWireLineWidth(final float fThickness)
+	{		
+		if(visRendersTimeMap.size()>0 )
+		{
+			final List<AbstractClipTransformVis> visRenders = new ArrayList<>(visRendersTimeMap.keySet());
+			for(final AbstractClipTransformVis visRender:visRenders)
+			{		
+				((VisMeshColor)visRender).setWireLineWidth( fThickness );
+			}
+		}
+	}
+	
+	
+	@Override
 	public void setSilhouetteDecay(final float silhouetteDecay_)
 	{	
 		if(visRendersTimeMap.size()>0 )
@@ -187,11 +213,7 @@ public class MultiMeshColor extends AbstractClipTransformMulti implements BasicM
 			}
 		}
 	}
-	@Override
-	public float getPointSize()
-	{
-		return ((VisMeshColor)visRendersTimeMap.keySet().toArray()[0]).fPointSize;
-	}
+
 
 	
 	@Override

--- a/src/main/resources/scene/mesh_color.fp
+++ b/src/main/resources/scene/mesh_color.fp
@@ -5,7 +5,6 @@ uniform int surfaceRender;
 in vec3 Normal;
 in vec3 FragPos;
 in vec3 posW;
-in vec3 bary;
 uniform int clipactive;
 uniform vec3 clipmin;
 uniform vec3 clipmax;
@@ -46,20 +45,6 @@ vec3 specular(vec3 norm, vec3 viewDir, vec3 lightDir, vec3 lightColor, float shi
 
 vec4 getGridColor(vec4 colorInp)
 {
-		
-	//barycentric
-	if(gridType == 1)
-	{
-		float d = min(min(bary.x, bary.y), bary.z);
-		if(d<0.05)
-		{
-			return colorInp;
-		}
-		else
-		{
-			discard;		
-		}
-	}
 	
 	//cartesian grid
 	if(gridType == 2)

--- a/src/main/resources/scene/mesh_color.vp
+++ b/src/main/resources/scene/mesh_color.vp
@@ -1,11 +1,9 @@
 layout (location = 0) in vec3 aPos;
 layout (location = 1) in vec3 aNormal;
-layout (location = 2) in vec3 baryin;
 
 out vec3 FragPos;
 out vec3 Normal;
 out vec3 posW;
-out vec3 bary;
 
 uniform mat4 pvm;
 uniform mat4 vm;
@@ -17,5 +15,4 @@ void main()
 	FragPos = vec3(vm * vec4( aPos, 1.0 ));
 	Normal = itvm * aNormal;
 	posW = aPos;
-	bary = baryin;
 }


### PR DESCRIPTION
Instead of using barycentric coordinates and a complicated shader,
now just using `glPolygonMode` to draw a wireframe of a mesh.

+ update GUI to include mesh grid type.